### PR TITLE
TitleBar: Toggle visibility instead of destroy

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -56,7 +56,7 @@ public class Spreadsheet.App : Gtk.Application {
             try {
                 var file = new Spreadsheet.Services.CSV.CSVParser.from_file (csv_file.get_path ()).parse ();
                 window.file = file;
-                window.header.init_header ();
+                window.header.set_buttons_visibility (true);
                 window.show_all ();
                 window.app_stack.set_visible_child_name ("app");
             } catch (Spreadsheet.Services.Parsing.ParserError err) {

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -182,7 +182,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
                 }
 
                 chooser.close ();
-                header.init_header ();
+                header.set_buttons_visibility (true);
                 show_all ();
                 app_stack.set_visible_child_name ("app");
             }
@@ -220,7 +220,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
                 list_item.clicked.connect (() => {
                     try {
                         this.file = new CSVParser.from_file (path).parse ();
-                        header.init_header ();
+                        header.set_buttons_visibility (true);
                         show_all ();
                         app_stack.set_visible_child_name ("app");
                         add_recents (path);
@@ -365,7 +365,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         string documents = "";
         File? path = null;
 
-        header.init_header ();
+        header.set_buttons_visibility (true);
 
         do {
             file_name = _("Untitled Spreadsheet %i").printf (id++);
@@ -498,7 +498,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
     }
 
     public void show_welcome () {
-        header.clear_header ();
+        header.set_buttons_visibility (false);
         header.set_titles (_("Spreadsheet"), null);
         expression.text = "";
 

--- a/src/UI/TitleBar.vala
+++ b/src/UI/TitleBar.vala
@@ -11,9 +11,7 @@ public class Spreadsheet.UI.TitleBar : Gtk.HeaderBar {
         );
     }
 
-    public void init_header () {
-        clear_header ();
-
+    construct {
         var file_ico = new Gtk.Image.from_icon_name ("window-new", Gtk.IconSize.SMALL_TOOLBAR);
         var file_button = new Gtk.ToolButton (file_ico, null);
         file_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>N"}, _("Open another window"));
@@ -54,12 +52,14 @@ public class Spreadsheet.UI.TitleBar : Gtk.HeaderBar {
         });
         pack_end (undo_button);
 
+        set_buttons_visibility (false);
         update_header ();
     }
 
-    public void clear_header () {
+    public void set_buttons_visibility (bool is_visible) {
         foreach (var button in get_children ()) {
-            button.destroy ();
+            button.visible = is_visible;
+            button.no_show_all = !is_visible;
         }
     }
 


### PR DESCRIPTION
The app destroys the buttons in the titlebar every time it shows the welcome screen at the moment, which may not be efficient. This PR toggles their visibility by using `visible` and `no_show_all` properties instead.
