### PR TITLE
Fix font color in style_toggle is not drawn when inactive with greenfield

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,0 +1,3 @@
+.toggle-button {
+	background: none;
+}

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,7 +1,5 @@
 icon_sizes = ['32', '48', '64', '128']
 
-file_name = 'spreadsheet'
-
 install_data(
     file_name + '.gschema.xml',
     rename: meson.project_name() + '.gschema.xml',

--- a/data/spreadsheet.gresource.xml
+++ b/data/spreadsheet.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/elework/spreadsheet">
+    <file alias="Application.css">Application.css</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('com.github.elework.spreadsheet', 'vala', 'c')
 
-gnome = import('gnome')
+file_name = 'spreadsheet'
 
 i18n = import('i18n')
 add_global_arguments(
@@ -8,7 +8,16 @@ add_global_arguments(
     language:'c'
 )
 
+gnome = import('gnome')
+asresources = gnome.compile_resources(
+    'as-resources',
+    join_paths('data', file_name + '.gresource.xml'),
+    source_dir: 'data',
+    c_name: 'as'
+)
+
 executable(meson.project_name(),
+    asresources,
     'src/AlphabetGenerator.vala',
     'src/App.vala',
     'src/Functions/Basic.vala',

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -113,6 +113,12 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
     }
 
     construct {
+        var cssprovider = new Gtk.CssProvider ();
+        cssprovider.load_from_resource ("/com/github/elework/spreadsheet/Application.css");
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (),
+                                                    cssprovider,
+                                                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
         app_stack = new Stack ();
         app_stack.add_named (welcome (), "welcome");
         app_stack.add_named (sheet (), "app");
@@ -309,6 +315,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         });
 
         style_toggle = new ToggleButton.with_label ("Open Sans 14");
+        style_toggle.get_style_context ().add_class ("toggle-button");
         style_toggle.tooltip_text = _("Set colors to letters in a selected cell");
         bool resized = false;
         style_toggle.draw.connect ((cr) => { // draw the color rectangle on the right of the style button


### PR DESCRIPTION
Fix visibility issue of the font color square in style_toggle when inactive. This issue only happens on the new stylesheet called Greenfield that will come with the next version of elementary OS.

## Before
![2020-08-26 07 49 25 の画面録画](https://user-images.githubusercontent.com/26003928/91235980-c1fb1600-e771-11ea-98c8-81ca05ded013.gif)

## After
![2020-08-26 07 45 36 の画面録画](https://user-images.githubusercontent.com/26003928/91235974-be678f00-e771-11ea-85ba-8eaf0c6d30e5.gif)
