### PR TITLE
StyleModal: Fix HeaderLabel layout and coding style

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,3 +1,7 @@
 .toggle-button {
 	background: none;
 }
+
+label.h4 {
+    margin: 0;
+}

--- a/src/Widgets/StyleModal.vala
+++ b/src/Widgets/StyleModal.vala
@@ -9,46 +9,49 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
 
     public StyleModal (FontStyle font_style, CellStyle cell_style) {
         var style_stack = new Gtk.Stack ();
-        style_stack.add_titled (fonts_grid (font_style), "fonts-grid", _("Font"));
-        style_stack.add_titled (cells_grid (cell_style), "cells-grid", _("Cell"));
+        style_stack.add_titled (create_fonts_grid (font_style), "fonts-grid", _("Font"));
+        style_stack.add_titled (create_cells_grid (cell_style), "cells-grid", _("Cell"));
 
-        var style_stacksw = new Gtk.StackSwitcher ();
-        style_stacksw.homogeneous = true;
-        style_stacksw.halign = Gtk.Align.CENTER;
-        style_stacksw.stack = style_stack;
+        var style_stack_switcher = new Gtk.StackSwitcher () {
+            homogeneous = true,
+            halign = Gtk.Align.CENTER,
+            stack = style_stack
+        };
 
-        attach (style_stacksw, 0, 0, 1, 1);
+        attach (style_stack_switcher, 0, 0, 1, 1);
         attach (style_stack, 0, 1, 1, 1);
     }
 
-    private Gtk.Grid fonts_grid (FontStyle font_style) {
+    private Gtk.Grid create_fonts_grid (FontStyle font_style) {
         // TODO: Add a widget that can choose a font and its size
 
-        var style_label = new Granite.HeaderLabel (_("Style"));
-        style_label.halign = Gtk.Align.START;
-
-        var bold_button = new Gtk.ToggleButton ();
+        var bold_button = new Gtk.ToggleButton () {
+            focus_on_click = false,
+            tooltip_text = _("Bold")
+        };
         bold_button.add (new Gtk.Image.from_icon_name ("format-text-bold-symbolic", Gtk.IconSize.BUTTON));
-        bold_button.focus_on_click = false;
-        bold_button.tooltip_text = _("Bold");
-        font_style.bind_property ("is_bold", bold_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        var italic_button = new Gtk.ToggleButton ();
+        var italic_button = new Gtk.ToggleButton () {
+            focus_on_click = false,
+            tooltip_text = _("Italic")
+        };
         italic_button.add (new Gtk.Image.from_icon_name ("format-text-italic-symbolic", Gtk.IconSize.BUTTON));
-        italic_button.focus_on_click = false;
-        italic_button.tooltip_text = _("Italic");
-        font_style.bind_property ("is_italic", italic_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        var underline_button = new Gtk.ToggleButton ();
+        var underline_button = new Gtk.ToggleButton () {
+            focus_on_click = false,
+            tooltip_text = _("Underline")
+        };
         underline_button.add (new Gtk.Image.from_icon_name ("format-text-underline-symbolic", Gtk.IconSize.BUTTON));
-        underline_button.focus_on_click = false;
-        underline_button.tooltip_text = _("Underline");
-        font_style.bind_property ("is_underline", underline_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        var strikethrough_button = new Gtk.ToggleButton ();
+        var strikethrough_button = new Gtk.ToggleButton () {
+            focus_on_click = false,
+            tooltip_text = _("Strikethrough")
+        };
         strikethrough_button.add (new Gtk.Image.from_icon_name ("format-text-strikethrough-symbolic", Gtk.IconSize.BUTTON));
-        strikethrough_button.focus_on_click = false;
-        strikethrough_button.tooltip_text = _("Strikethrough");
+
+        font_style.bind_property ("is_bold", bold_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+        font_style.bind_property ("is_italic", italic_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+        font_style.bind_property ("is_underline", underline_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
         font_style.bind_property ("is_strikethrough", strikethrough_button, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
         var style_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
@@ -58,28 +61,29 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
         style_box.pack_start (underline_button);
         style_box.pack_start (strikethrough_button);
 
-        var color_label = new Granite.HeaderLabel (_("Color"));
-        color_label.halign = Gtk.Align.START;
-        color_button = new Gtk.ColorButton ();
-        color_button.halign = Gtk.Align.START;
-        color_button.tooltip_text = _("Set font color of a selected cell");
+        color_button = new Gtk.ColorButton () {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Set font color of a selected cell")
+        };
         font_style.bind_property ("fontcolor", color_button, "rgba", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
-        color_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON);
-        color_reset_button.halign = Gtk.Align.START;
-        color_reset_button.tooltip_text = _("Reset font color of a selected cell to black");
+
+        color_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Reset font color of a selected cell to black")
+        };
 
         var right_grid = new Gtk.Grid ();
-        right_grid.margin = 6;
-        right_grid.attach (style_label, 0, 0, 1, 1);
+        right_grid.attach (new Granite.HeaderLabel (_("Style")), 0, 0, 1, 1);
         right_grid.attach (style_box, 0, 1, 1, 1);
-        right_grid.attach (color_label, 0, 2, 1, 1);
+        right_grid.attach (new Granite.HeaderLabel (_("Color")), 0, 2, 1, 1);
         right_grid.attach (color_button, 0, 3, 1, 1);
         right_grid.attach (color_reset_button, 1, 3, 1, 1);
 
-        var fonts_grid = new Gtk.Grid ();
-        fonts_grid.margin_top = 6;
-        fonts_grid.orientation = Gtk.Orientation.VERTICAL;
-        fonts_grid.column_spacing = 6;
+        var fonts_grid = new Gtk.Grid () {
+            margin_top = 6,
+            orientation = Gtk.Orientation.VERTICAL,
+            column_spacing = 6
+        };
         fonts_grid.attach (right_grid, 0, 0, 1, 1);
 
         // Set the sensitivity of the color_reset_button by whether it has already reset font color to the default one or not when…
@@ -99,39 +103,44 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
         return fonts_grid;
     }
 
-    private Gtk.Grid cells_grid (CellStyle cell_style) {
-        var cells_grid = new Gtk.Grid ();
-        cells_grid.margin_top = 6;
-        cells_grid.column_spacing = 6;
+    private Gtk.Grid create_cells_grid (CellStyle cell_style) {
+        bg_button = new Gtk.ColorButton () {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Set fill color of a selected cell")
+        };
 
-        var bg_label = new Granite.HeaderLabel (_("Fill"));
-        bg_label.halign = Gtk.Align.START;
-        bg_button = new Gtk.ColorButton ();
-        bg_button.halign = Gtk.Align.START;
-        bg_button.tooltip_text = _("Set fill color of a selected cell");
+        bg_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Remove fill color of a selected cell")
+        };
+
+        sr_button = new Gtk.ColorButton () {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Set stroke color of a selected cell")
+        };
+
+        sr_width_spin = new Gtk.SpinButton.with_range (0.1, 3, 0.1) {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Set the border width of a selected cell")
+        };
+
+        sr_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
+            halign = Gtk.Align.START,
+            tooltip_text = _("Remove stroke color of a selected cell")
+        };
+
         cell_style.bind_property ("background", bg_button, "rgba", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
-        bg_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON);
-        bg_reset_button.halign = Gtk.Align.START;
-        bg_reset_button.tooltip_text = _("Remove fill color of a selected cell");
-
-        var sr_label = new Granite.HeaderLabel (_("Stroke"));
-        sr_label.halign = Gtk.Align.START;
-        sr_button = new Gtk.ColorButton ();
-        sr_button.halign = Gtk.Align.START;
-        sr_button.tooltip_text = _("Set stroke color of a selected cell");
         cell_style.bind_property ("stroke", sr_button, "rgba", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
-        sr_width_spin = new Gtk.SpinButton.with_range (0.1, 3, 0.1);
-        sr_width_spin.halign = Gtk.Align.START;
-        sr_width_spin.tooltip_text = _("Set the border width of a selected cell");
         cell_style.bind_property ("stroke_width", sr_width_spin, "value", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
-        sr_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON);
-        sr_reset_button.halign = Gtk.Align.START;
-        sr_reset_button.tooltip_text = _("Remove stroke color of a selected cell");
 
-        cells_grid.attach (bg_label, 0, 0, 1, 1);
+        var cells_grid = new Gtk.Grid () {
+            margin_top = 6,
+            column_spacing = 6
+        };
+        cells_grid.attach (new Granite.HeaderLabel (_("Fill")), 0, 0, 1, 1);
         cells_grid.attach (bg_button, 0, 1, 1, 1);
         cells_grid.attach (bg_reset_button, 1, 1, 1, 1);
-        cells_grid.attach (sr_label, 0, 2, 1, 1);
+        cells_grid.attach (new Granite.HeaderLabel (_("Stroke")), 0, 2, 1, 1);
         cells_grid.attach (sr_button, 0, 3, 1, 1);
         cells_grid.attach (sr_width_spin, 1, 3, 1, 1);
         cells_grid.attach (sr_reset_button, 2, 3, 1, 1);

--- a/src/Widgets/StyleModal.vala
+++ b/src/Widgets/StyleModal.vala
@@ -1,12 +1,4 @@
 public class Spreadsheet.StyleModal : Gtk.Grid {
-    private Gtk.ColorButton color_button;
-    private Gtk.Button color_reset_button;
-    private Gtk.ColorButton bg_button;
-    private Gtk.Button bg_reset_button;
-    private Gtk.ColorButton sr_button;
-    private Gtk.SpinButton sr_width_spin;
-    private Gtk.Button sr_reset_button;
-
     public StyleModal (FontStyle font_style, CellStyle cell_style) {
         var style_stack = new Gtk.Stack ();
         style_stack.add_titled (create_fonts_grid (font_style), "fonts-grid", _("Font"));
@@ -61,13 +53,13 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
         style_box.pack_start (underline_button);
         style_box.pack_start (strikethrough_button);
 
-        color_button = new Gtk.ColorButton () {
+        var color_button = new Gtk.ColorButton () {
             halign = Gtk.Align.START,
             tooltip_text = _("Set font color of a selected cell")
         };
         font_style.bind_property ("fontcolor", color_button, "rgba", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        color_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
+        var color_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
             halign = Gtk.Align.START,
             tooltip_text = _("Reset font color of a selected cell to black")
         };
@@ -104,27 +96,27 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
     }
 
     private Gtk.Grid create_cells_grid (CellStyle cell_style) {
-        bg_button = new Gtk.ColorButton () {
+        var bg_button = new Gtk.ColorButton () {
             halign = Gtk.Align.START,
             tooltip_text = _("Set fill color of a selected cell")
         };
 
-        bg_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
+        var bg_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
             halign = Gtk.Align.START,
             tooltip_text = _("Remove fill color of a selected cell")
         };
 
-        sr_button = new Gtk.ColorButton () {
+        var sr_button = new Gtk.ColorButton () {
             halign = Gtk.Align.START,
             tooltip_text = _("Set stroke color of a selected cell")
         };
 
-        sr_width_spin = new Gtk.SpinButton.with_range (0.1, 3, 0.1) {
+        var sr_width_spin = new Gtk.SpinButton.with_range (0.1, 3, 0.1) {
             halign = Gtk.Align.START,
             tooltip_text = _("Set the border width of a selected cell")
         };
 
-        sr_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
+        var sr_reset_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON) {
             halign = Gtk.Align.START,
             tooltip_text = _("Remove stroke color of a selected cell")
         };


### PR DESCRIPTION
## Before
![Screenshot from 2021-04-21 10-44-09](https://user-images.githubusercontent.com/26003928/115484957-b58e7500-a28e-11eb-88ad-1a7a8a9934d2.png)

## After
![Screenshot from 2021-04-21 10-44-27](https://user-images.githubusercontent.com/26003928/115484962-b7f0cf00-a28e-11eb-8919-ff4cad1c1a5f.png)

- `Granite.HeaderLabel` now sets left and right margins in popovers and it makes the layout broken so disabled it
- `Granite.HeaderLabel` has the property `halign` to `Gtk.Align.START` by default so removed it
- Readable variable and function name
