### PR TITLE
Flatpak: Revoke access to AccountsService

### DIFF
--- a/com.github.elework.spreadsheet.yml
+++ b/com.github.elework.spreadsheet.yml
@@ -9,8 +9,6 @@ finish-args:
   - '--socket=fallback-x11'
   - '--device=dri'
   - '--filesystem=xdg-documents'
-  # needed for perfers-color-scheme
-  - '--system-talk-name=org.freedesktop.Accounts'
 modules:
   - name: spreadsheet
     buildsystem: meson


### PR DESCRIPTION
We don't need this since Flatpak Platform 6.0.2
