### PR TITLE
meson: Remove enable_debug option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,10 +13,6 @@ add_global_arguments(
     language:'c'
 )
 
-if get_option('enable_debug')
-    add_project_arguments('--debug', language: 'vala')
-endif
-
 config_data = configuration_data()
 config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
 config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('enable_debug', type: 'boolean', value: 'false', description: 'Enable this when debugging in Visual Studio Code using GDB')


### PR DESCRIPTION
I prefer vim/neovim than VSCode now