### PR TITLE
Setup OS-wide dark preference in startup

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -27,6 +27,18 @@ public class Spreadsheet.App : Gtk.Application {
     protected override void startup () {
         base.startup ();
 
+        // Follow OS-wide dark preference
+        unowned var granite_settings = Granite.Settings.get_default ();
+        unowned var gtk_settings = Gtk.Settings.get_default ();
+
+        granite_settings.bind_property ("prefers-color-scheme", gtk_settings, "gtk-application-prefer-dark-theme",
+            BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
+            (binding, granite_prop, ref gtk_prop) => {
+                gtk_prop = (Granite.Settings.ColorScheme) granite_prop == Granite.Settings.ColorScheme.DARK;
+                return true;
+            }
+        );
+
         setup_shortcuts ();
     }
 

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -132,16 +132,6 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
 
         add (app_stack);
         show_welcome ();
-
-        // Follow elementary OS-wide dark preference
-        var granite_settings = Granite.Settings.get_default ();
-        var gtk_settings = Gtk.Settings.get_default ();
-
-        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-
-        granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-        });
     }
 
     protected override bool configure_event (Gdk.EventConfigure event) {


### PR DESCRIPTION
So that it's applied to windows/dialogs independent from MainWindow, while they don't exist at the moment
