### PR TITLE
FunctionListRow: Rewrite with GTK 4 prep

### DIFF
--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -278,21 +278,16 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         foreach (var func in FunctionManager.get_default ().functions) {
             functions_liststore.append (new FuncSearchList (func.name, func.doc));
 
-            var row = new ListBoxRow ();
-            row.selectable = false;
-            row.margin_top = 3;
-            row.margin_bottom = 3;
-            row.add (new FunctionListRow (func));
-            row.realize.connect (() => {
-                row.get_window ().cursor = new Cursor.from_name (row.get_display (), "pointer");
-            });
-            row.button_press_event.connect ((evt) => {
-                expression.text += ")";
-                expression.buffer.insert_text (expression.get_position (), (func.name + "(").data);
-                return true;
-            });
+            var row = new FunctionListRow (func);
             function_list.add (row);
         }
+
+        function_list.row_activated.connect ((row) => {
+            var func_row = row as FunctionListRow;
+
+            expression.text += ")";
+            expression.buffer.insert_text (expression.get_position (), (func_row.function.name + "(").data);
+        });
 
         var function_list_search_entry = new SearchEntry ();
         function_list_search_entry.margin_bottom = 6;

--- a/src/Widgets/FunctionListRow.vala
+++ b/src/Widgets/FunctionListRow.vala
@@ -1,24 +1,39 @@
-using Gtk;
 using Spreadsheet.Models;
 
-public class Spreadsheet.Widgets.FunctionListRow : EventBox {
-    public Function function { get; set; }
+public class Spreadsheet.Widgets.FunctionListRow : Gtk.ListBoxRow {
+    public Function function { get; construct; }
 
-    public FunctionListRow (Function func) {
-        var box = new Box (Orientation.VERTICAL, 0);
-        function = func;
+    public FunctionListRow (Function function) {
+        Object (
+            function: function
+        );
+    }
 
-        var name_label = new Label (function.name);
-        name_label.justify = Justification.LEFT;
-        name_label.halign = Align.START;
-        box.pack_start (name_label);
+    construct {
+        var name_label = new Gtk.Label (function.name) {
+            justify = Gtk.Justification.LEFT,
+            halign = Gtk.Align.START,
+        };
 
-        var doc_label = new Label (function.doc);
-        doc_label.justify = Justification.FILL;
-        doc_label.halign = Align.START;
+        var doc_label = new Gtk.Label (function.doc) {
+            justify = Gtk.Justification.FILL,
+            halign = Gtk.Align.START,
+        };
         doc_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
+        var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        box.pack_start (name_label);
         box.pack_start (doc_label);
 
-        add (box);
+        selectable = false;
+        margin_top = 3;
+        margin_bottom = 3;
+
+        realize.connect (() => {
+            // Use the pointing hand cursor instead of the normal arrow cursor
+            get_window ().cursor = new Gdk.Cursor.from_name (get_display (), "pointer");
+        });
+
+        child = box;
     }
 }


### PR DESCRIPTION
- Subclass Gtk.ListBoxRow directly instead of Gtk.EventBox (part of #133)
- Lessen scope of `function`
- Use GObject-style construction
- Explicit namespace if it's short
- Change cursor shape in the class instead of the caller side
