### PR TITLE
RecentsManager: Shorten and readable method names

### DIFF
--- a/src/Services/RecentsManager.vala
+++ b/src/Services/RecentsManager.vala
@@ -23,22 +23,22 @@ public class Spreadsheet.Services.RecentsManager : Object {
     construct {
         // TODO: Replace with Gtk.StringList after porting to GTK 4
         recents_liststore = new ListStore (typeof (StringObject));
-        recents_init ();
-        recents_sync ();
+        load ();
+        sync ();
     }
 
-    private void recents_init () {
+    private void load () {
         recents_liststore.remove_all ();
 
         var recents_gsettings = Spreadsheet.App.settings.get_strv ("recent-files");
 
         int recents_num = int.min (recents_gsettings.length, RECENTS_NUM_MAX);
         for (int i_rev = (recents_num - 1); i_rev >= 0; i_rev--) {
-            add_recents_internal (recents_gsettings[i_rev]);
+            prepend_internal (recents_gsettings[i_rev]);
         }
     }
 
-    private void recents_sync () {
+    private void sync () {
         var new_recents = new Array<string> ();
 
         uint recents_num = uint.min (recents_liststore.n_items, RECENTS_NUM_MAX);
@@ -50,13 +50,13 @@ public class Spreadsheet.Services.RecentsManager : Object {
         Spreadsheet.App.settings.set_strv ("recent-files", new_recents.data);
     }
 
-    private void recents_cut_off (uint preserve_count) {
+    private void cut_off (uint preserve_count) {
         for (uint i = preserve_count; i < recents_liststore.n_items; i++) {
             recents_liststore.remove (i);
         }
     }
 
-    private bool add_recents_internal (string path) {
+    private bool prepend_internal (string path) {
         var file = File.new_for_path (path);
         if (!file.query_exists ()) {
             warning ("Invalid path. path=%s", path);
@@ -77,19 +77,19 @@ public class Spreadsheet.Services.RecentsManager : Object {
             recents_liststore.remove (pos);
         }
 
-        recents_cut_off (RECENTS_NUM_MAX - 1);
+        cut_off (RECENTS_NUM_MAX - 1);
 
         recents_liststore.insert (0, path_obj);
 
         return true;
     }
 
-    public void add_recents (string path) {
-        bool ret = add_recents_internal (path);
+    public void prepend (string path) {
+        bool ret = prepend_internal (path);
         if (!ret) {
             return;
         }
 
-        recents_sync ();
+        sync ();
     }
 }

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -480,7 +480,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         }
 
         this.file = file;
-        recents_manager.add_recents (file.file_path);
+        recents_manager.prepend (file.file_path);
         header.set_buttons_visibility (true);
         app_stack.visible_child = edit_view;
         show_all ();
@@ -491,7 +491,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
     // Triggered when an opened sheet is modified
     public void save_sheet () {
         new CSVWriter (active_sheet.page).write_to_file (file.file_path);
-        recents_manager.add_recents (file.file_path);
+        recents_manager.prepend (file.file_path);
     }
 
     private void save_as_sheet () {
@@ -518,7 +518,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
             }
 
             new CSVWriter (active_sheet.page).write_to_file (path);
-            recents_manager.add_recents (path);
+            recents_manager.prepend (path);
 
             // Open the saved file
             try {


### PR DESCRIPTION
- Remove redundant `recents_`; it's implicit about recent files because these methods are in RecentsManager
- Use concrete words instead of generic ones: `load` instead of `init` and `prepend` instead of `add`
