### PR TITLE
Add SPDX license header

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before writing some code, let the others know on what you'll be working. The bes
 We follow the [coding style of elementary OS](https://docs.elementary.io/develop/writing-apps/code-style) and [its Human Interface Guidelines](https://docs.elementary.io/hig#human-interface-guidelines) in our code, please try to respect them. But there are two differences:
 
 * We also name our namespaces after the folder they are in (e.g. `Spreadsheet.Services.Formula.AST` is in `src/Services/Formula/AST`)
-* We don't put the GPL in every file, since the project is licensed under the MIT license
+* The project is licensed under the MIT license unlike most of the projects in the elementary ecosystem. Make sure you will NEVER bring codes licensed under copyleft!
 
 ### Translating This App
 

--- a/src/AlphabetGenerator.vala
+++ b/src/AlphabetGenerator.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 /**
  * Generates identifier using the alphabet and an index.
  *

--- a/src/App.vala
+++ b/src/App.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Services.CSV;
 using Spreadsheet.Services.Parsing;
 using Spreadsheet.UI;

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,2 +1,7 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
 public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/Functions/Basic.vala
+++ b/src/Functions/Basic.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 namespace Spreadsheet.Functions {
     private double number (Value num) {
         Type num_type = num.type ();

--- a/src/Functions/Geometry.vala
+++ b/src/Functions/Geometry.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 namespace Spreadsheet.Functions {
     public Value cos (Value[] args) {
         return Math.cos (number (args[0]));

--- a/src/Models/Cell.vala
+++ b/src/Models/Cell.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Services.Formula;
 using Spreadsheet.Services.Parsing;
 

--- a/src/Models/CellStyle.vala
+++ b/src/Models/CellStyle.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.CellStyle : Object {
     public const Gdk.RGBA BG_COLOR_DEFAULT = { 1, 1, 1, 1 };
 

--- a/src/Models/FontStyle.vala
+++ b/src/Models/FontStyle.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.FontStyle : Object {
     public const Gdk.RGBA FONT_COLOR_DEFAULT = { 0, 0, 0, 1 };
 

--- a/src/Models/Function.vala
+++ b/src/Models/Function.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.Models.Function : Object {
     public string name { get; construct; }
     public ApplyFunc apply { get; construct; }

--- a/src/Models/HistoryAction.vala
+++ b/src/Models/HistoryAction.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.Models.StateChange<G> : Object {
     public G before;
     public G after;

--- a/src/Models/Page.vala
+++ b/src/Models/Page.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 /**
 * A single page of a Spreadsheet
 */

--- a/src/Models/Spreadsheet.vala
+++ b/src/Models/Spreadsheet.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 /**
 * Class representing a whole Spreadsheet file.
 */

--- a/src/Models/StringObject.vala
+++ b/src/Models/StringObject.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.Models.StringObject : Object {
     public string string { get; construct; }
 

--- a/src/Services/CSV/CSVGrammar.vala
+++ b/src/Services/CSV/CSVGrammar.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Services.Parsing;
 
 public class Spreadsheet.Services.CSV.CSVGrammar : Grammar {

--- a/src/Services/CSV/CSVParser.vala
+++ b/src/Services/CSV/CSVParser.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Services.Parsing;
 using Spreadsheet.Models;
 using Gee;

--- a/src/Services/CSV/CSVWriter.vala
+++ b/src/Services/CSV/CSVWriter.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Gee;
 using Spreadsheet.Models;
 

--- a/src/Services/Formula/AST/CallExpression.vala
+++ b/src/Services/Formula/AST/CallExpression.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 using Spreadsheet.Services;
 

--- a/src/Services/Formula/AST/CellReference.vala
+++ b/src/Services/Formula/AST/CellReference.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public class Spreadsheet.Services.Formula.AST.CellReference : Expression {

--- a/src/Services/Formula/AST/Expression.vala
+++ b/src/Services/Formula/AST/Expression.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public abstract class Spreadsheet.Services.Formula.AST.Expression : Object {

--- a/src/Services/Formula/AST/NumberExpression.vala
+++ b/src/Services/Formula/AST/NumberExpression.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public class Spreadsheet.Services.Formula.AST.NumberExpression : Expression {

--- a/src/Services/Formula/AST/TextExpression.vala
+++ b/src/Services/Formula/AST/TextExpression.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public class Spreadsheet.Services.Formula.AST.TextExpression : Expression {

--- a/src/Services/Formula/FormulaGrammar.vala
+++ b/src/Services/Formula/FormulaGrammar.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Services;
 using Spreadsheet.Services.Parsing;
 

--- a/src/Services/Formula/FormulaParser.vala
+++ b/src/Services/Formula/FormulaParser.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Services.Formula.AST;
 using Spreadsheet.Services.Parsing;
 

--- a/src/Services/FuncSearchList.vala
+++ b/src/Services/FuncSearchList.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.Services.FuncSearchList : Object {
     public string funcsearchlist_item { get; set; }
 

--- a/src/Services/FunctionManager.vala
+++ b/src/Services/FunctionManager.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public class Spreadsheet.Services.FunctionManager : Object {

--- a/src/Services/HistoryManager.vala
+++ b/src/Services/HistoryManager.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public class Spreadsheet.Services.HistoryManager : Object {

--- a/src/Services/Parsing/Evaluator.vala
+++ b/src/Services/Parsing/Evaluator.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public delegate Spreadsheet.Services.Parsing.Token Evaluation (string match);
 
 public class Spreadsheet.Services.Parsing.Evaluator : Object {

--- a/src/Services/Parsing/Grammar.vala
+++ b/src/Services/Parsing/Grammar.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public abstract class Spreadsheet.Services.Parsing.Grammar : Object {
     public Gee.HashMap<string, Gee.ArrayList<Evaluator>> rules {
         get;

--- a/src/Services/Parsing/Lexer.vala
+++ b/src/Services/Parsing/Lexer.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Gee;
 
 public class Spreadsheet.Services.Parsing.Lexer : Object {

--- a/src/Services/Parsing/Parser.vala
+++ b/src/Services/Parsing/Parser.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Gee;
 
 public errordomain Spreadsheet.Services.Parsing.ParserError {

--- a/src/Services/Parsing/Token.vala
+++ b/src/Services/Parsing/Token.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.Services.Parsing.Token {
 
     public string kind;

--- a/src/Services/RecentsManager.vala
+++ b/src/Services/RecentsManager.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 /**

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Widgets;
 using Spreadsheet.Models;
 using Spreadsheet.Services;

--- a/src/UI/WelcomeView.vala
+++ b/src/UI/WelcomeView.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 using Spreadsheet.Services;
 

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 namespace Spreadsheet.Util {
     // From http://stackoverflow.com/questions/4183546/how-can-i-draw-image-with-rounded-corners-in-cairo-gtk
     public static void draw_rounded_path (Cairo.Context ctx, double x, double y, double width, double height, double radius) {

--- a/src/Widgets/ActionBar.vala
+++ b/src/Widgets/ActionBar.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.Widgets.ActionBar : Gtk.Bin {
     public signal void zoom_level_changed ();
 

--- a/src/Widgets/FunctionListRow.vala
+++ b/src/Widgets/FunctionListRow.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.Models;
 
 public class Spreadsheet.Widgets.FunctionListRow : Gtk.ListBoxRow {

--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Gdk;
 using Gee;
 using Gtk;

--- a/src/Widgets/StyleModal.vala
+++ b/src/Widgets/StyleModal.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 public class Spreadsheet.StyleModal : Gtk.Grid {
     public StyleModal (FontStyle font_style, CellStyle cell_style) {
         var style_stack = new Gtk.Stack ();

--- a/src/Widgets/TitleBar.vala
+++ b/src/Widgets/TitleBar.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
 using Spreadsheet.UI;
 
 public class Spreadsheet.Widgets.TitleBar : Gtk.HeaderBar {


### PR DESCRIPTION
This is kind of redundant and verbose thing, but I think we need this to indicate to contributors that the project is not licensed under GPL but MIT, so they must not copy & paste codes from most of elementary projects.
