### PR TITLE
MainWindow: Fix missing suffix in the titlebar when new file

### DIFF
--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -461,8 +461,8 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         page.title = _("Sheet 1");
 
         var file = new SpreadSheet ();
-        file.title = file_name;
         file.file_path = path.get_path ();
+        file.title = Path.get_basename (file.file_path);
         file.add_page (page);
         this.file = file;
 


### PR DESCRIPTION
This PR fixes the titlebar label has no `.csv` suffix when creating new file.

<img width="1031" height="205" alt="スクリーンショット 2025-08-17 14 59 47" src="https://github.com/user-attachments/assets/45334997-e6a3-4a59-8319-1c982217b832" />
