### PR TITLE
Introduce RoundedSquare

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,7 +1,3 @@
-.style-button {
-    background: none;
-}
-
 .func-list-button {
     font-style: italic;
     font-weight: bold;

--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ sources = files(
     'src' / 'UI' / 'WelcomeView.vala',
     'src' / 'Widgets' / 'ActionBar.vala',
     'src' / 'Widgets' / 'FunctionListRow.vala',
+    'src' / 'Widgets' / 'RoundedSquare.vala',
     'src' / 'Widgets' / 'Sheet.vala',
     'src' / 'Widgets' / 'StyleModal.vala',
 )

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -291,30 +291,21 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
             function_list.invalidate_filter ();
         });
 
+        var font_name_label = new Gtk.Label ("Open Sans 14");
+
+        Gdk.RGBA font_color = { 0.0, 0.0, 0.0, 1.0 };
+        var font_color_square = new RoundedSquare (font_color, 18, 18, 2) {
+            halign = Gtk.Align.END
+        };
+
+        var style_summary = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 19);
+        style_summary.pack_start (font_name_label);
+        style_summary.pack_start (font_color_square);
+
         style_button = new Gtk.MenuButton () {
-            label = "Open Sans 14",
+            child = style_summary,
             tooltip_text = _("Set colors to letters in a selected cell")
         };
-        style_button.get_style_context ().add_class ("style-button");
-        bool resized = false;
-        style_button.draw.connect ((cr) => { // draw the color rectangle on the right of the style button
-            int spacing = 10;
-            int padding = 5;
-            int border = get_style_context ().get_border (StateFlags.NORMAL).left;
-            int square_size = style_button.get_allocated_height () - (border * 2);
-            int width = style_button.get_allocated_width ();
-
-            if (!resized) {
-                style_button.get_child ().halign = Gtk.Align.START;
-                style_button.width_request += width + spacing + square_size + border; // some space for the color icon
-                resized = true;
-            }
-
-            cr.set_source_rgb (0, 0, 0);
-            Util.draw_rounded_path (cr, width - (border + square_size - padding), border + padding, square_size - (padding * 2), square_size - (padding * 2), 2);
-            cr.fill ();
-            return false;
-        });
 
         style_popup = new Popover (style_button) {
             modal = true,

--- a/src/Widgets/RoundedSquare.vala
+++ b/src/Widgets/RoundedSquare.vala
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2017-2025 Spreadsheet Developers
+ */
+
+public class Spreadsheet.Widgets.RoundedSquare : Gtk.DrawingArea {
+    public Gdk.RGBA color { get; construct; }
+    public int width { get; construct; }
+    public int height { get; construct; }
+    public int radius { get; construct; }
+
+    public RoundedSquare (Gdk.RGBA color, int width, int height, int radius) {
+        Object (
+            color: color,
+            width: width,
+            height: height,
+            radius: radius
+        );
+    }
+
+    construct {
+        set_size_request (width, height);
+    }
+
+    protected override bool draw (Cairo.Context cr) {
+        Gdk.cairo_set_source_rgba (cr, color);
+        Util.draw_rounded_path (cr, 0, 0, width, height, radius);
+        cr.fill ();
+
+        return true;
+    }
+}


### PR DESCRIPTION
Towards #132

Create a new class based on Gtk.DrawingArea instead of hacky code in the `draw()` signal handler.

## Before
<img width="898" height="825" alt="image" src="https://github.com/user-attachments/assets/e088211f-ff13-4b81-8247-1337947b308b" />

## After
<img width="898" height="825" alt="image" src="https://github.com/user-attachments/assets/665f3dfb-c4b4-426e-a4dc-c5039f8cc0ba" />
