### PR TITLE
Esc to reset changes instead of clear

### DIFF
--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -397,7 +397,15 @@ public class Spreadsheet.UI.MainWindow : Gtk.ApplicationWindow {
         }
 
         active_sheet.grab_focus ();
-        formula_entry.text = "";
+
+        // Reset undecided changes
+        Cell? selected_cell = active_sheet.selected_cell;
+        if (selected_cell == null) {
+            formula_entry.text = "";
+            return;
+        }
+
+        formula_entry.text = selected_cell.formula;
     }
 
     private void new_sheet () {


### PR DESCRIPTION
This PR changes the behavior when pressing Esc on the formula entry.

## Before
The text of the formula entry is cleared:

[Kooha-2025-08-23-16-54-21.webm](https://github.com/user-attachments/assets/7677de64-8dd3-4e2b-acfa-3d45ed3ebbb0)

## After
The text of the formula entry is now reset to the last decided formula:

[Kooha-2025-08-23-16-53-04.webm](https://github.com/user-attachments/assets/7c8ad323-f026-405c-ad26-3e52cf758356)
